### PR TITLE
Fix missing autofocus on desktop

### DIFF
--- a/src/Utils/useAutoFocus.ts
+++ b/src/Utils/useAutoFocus.ts
@@ -16,7 +16,7 @@ export const useAutoFocus = (shouldAutoFocus: boolean) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   useEffectOnceWhen(() => {
-    if (inputRef.current && !ismobilejs()) {
+    if (inputRef.current && !ismobilejs().any) {
       inputRef.current.focus();
     }
   }, shouldAutoFocus);


### PR DESCRIPTION
Very minor fix, hehe. `ismobilejs()` returns an object, not a boolean. This object consists of boolean properties, describing exactly what kind of device is active.  If you want to catch any mobile/tablet device, you can use the property `any` as implemented in this commit. 