### PR TITLE
Allow setting the store key on previeus insurer provider

### DIFF
--- a/src/Components/Actions/Action.tsx
+++ b/src/Components/Actions/Action.tsx
@@ -127,6 +127,7 @@ export const Action = (props: ActionProps) => {
         next={props.action.data.next.name}
         skipLink={props.action.data.skip}
         onContinue={next => props.changePassage(next)}
+        storeKey={props.action.data.storeKey}
       />
     );
   }

--- a/src/Components/Actions/PreviousInsuranceProviderAction/index.tsx
+++ b/src/Components/Actions/PreviousInsuranceProviderAction/index.tsx
@@ -32,6 +32,7 @@ interface PreviousInsuranceProviderActionProps {
   onContinue: (name: string) => void;
   tooltip?: any;
   skipLink: { name: string; label: string };
+  storeKey?: string;
 }
 
 export const PreviousInsuranceProviderAction: React.FC<PreviousInsuranceProviderActionProps> = ({
@@ -40,7 +41,8 @@ export const PreviousInsuranceProviderAction: React.FC<PreviousInsuranceProvider
   next,
   onContinue,
   passageName,
-  skipLink
+  skipLink,
+  storeKey = "currentInsurer"
 }) => {
   const { setValue } = React.useContext(StoreContext);
   const { externalInsuranceProviderOtherProviderButton } = React.useContext(
@@ -56,11 +58,11 @@ export const PreviousInsuranceProviderAction: React.FC<PreviousInsuranceProvider
             onlyAcceptProvidersWithExternalCapabilities={false}
             onPickProvider={provider => {
               if (provider) {
-                setValue("currentInsurer", provider.id);
+                setValue(storeKey, provider.id);
                 setValue(`${passageName}Result`, provider.name);
                 onContinue(next);
               } else {
-                setValue("previousInsurer", "other");
+                setValue(storeKey, "other");
                 setValue(
                   `${passageName}Result`,
                   externalInsuranceProviderOtherProviderButton

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -309,6 +309,7 @@ const getPreviousInsuranceProviderAction = (
   const providers = previousInsuranceProviderActionNode.getAttribute(
     "providers"
   );
+  const storeKey = previousInsuranceProviderActionNode.getAttribute("key");
 
   const tooltip = parseTooltips(previousInsuranceProviderActionNode)[0];
 
@@ -318,6 +319,7 @@ const getPreviousInsuranceProviderAction = (
       next: nextLinks && nextLinks[0],
       skip: skipLinks && skipLinks[0],
       providers,
+      storeKey,
       ...(tooltip && { tooltip })
     }
   };
@@ -724,7 +726,7 @@ const parseTracks = (element: Element) => {
       const eventKeys = trackElement.getAttribute("keys") || "";
       const includeAllKeys = trackElement.getAttribute("includeAllKeys");
       const customData = trackElement.getAttribute("customData")
-        ? trackElement.getAttribute("customData").replace(/'/g, '"')
+        ? trackElement.getAttribute("customData")!.replace(/'/g, '"')
         : null;
 
       if (!eventName) {


### PR DESCRIPTION
Also, we should update HedvigInsurance/embark-docs so that end users can know `PreviousInsuranceProviderAction` can take this property.