### PR TITLE
Resolve birthdate reverse age correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "koa-mount": "^4.0.0",
     "koa-static": "^5.0.0",
     "lodash.get": "^4.4.2",
-    "react": "^16.11.0",
-    "react-dom": "^16.10.2",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
     "react-emotion": "^10.0.0",
     "react-hot-loader": "^4.12.19",
     "react-input-mask": "^2.0.4",
@@ -65,8 +65,8 @@
     "@emotion/core": "10.0.x",
     "@emotion/styled": "^10.0.x",
     "framer-motion": "1.6.x",
-    "react": "16.11.x",
-    "react-dom": "^16.10.x"
+    "react": "16.13.x",
+    "react-dom": "16.13.x"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",

--- a/src/Components/Actions/masking.test.tsx
+++ b/src/Components/Actions/masking.test.tsx
@@ -1,0 +1,127 @@
+import {
+  derivedValues,
+  isValid,
+  mapMaskedValue,
+  mapUnmaskedValue,
+  unmaskValue,
+} from './masking'
+import { differenceInYears } from 'date-fns'
+
+describe('isValid', () => {
+  it('validates PersonalNumber mask', () => {
+    const validPersonalNumber = '121212-1212'
+    expect(isValid('PersonalNumber', validPersonalNumber)).toBe(true)
+    const invalidPersonalNumber = 'not a valid personal number'
+    expect(isValid('PersonalNumber', invalidPersonalNumber)).toBe(false)
+  })
+
+  it('validates PostalCode mask', () => {
+    const validPostalCode = '12345'
+    expect(isValid('PostalCode', validPostalCode)).toBe(true)
+    const invalidPostalCode = 'not a valid postal code'
+    expect(isValid('PostalCode', invalidPostalCode)).toBe(false)
+  })
+
+  it('validates NorwegianPostalCode mask', () => {
+    const validPostalCode = '1234'
+    expect(isValid('NorwegianPostalCode', validPostalCode)).toBe(true)
+    const invalidPostalCode = 'not a valid postal code'
+    expect(isValid('NorwegianPostalCode', invalidPostalCode)).toBe(false)
+  })
+
+  it('validates email mask', () => {
+    const validEmail = 'my@mail.here'
+    expect(isValid('Email', validEmail)).toBe(true)
+    const invalidEmail = 'not a valid email'
+    expect(isValid('Email', invalidEmail)).toBe(false)
+  })
+
+  it('validates BirthDate mask', () => {
+    const validBirthDate = '1912-12-12'
+    expect(isValid('BirthDate', validBirthDate)).toBe(true)
+    const invalidBirthDate = 'not a valid birth date'
+    expect(isValid('BirthDate', invalidBirthDate)).toBe(false)
+  })
+
+  it('validates BirthDateReverse mask', () => {
+    const validBirthDate = '12-12-1912'
+    expect(isValid('BirthDateReverse', validBirthDate)).toBe(true)
+    const invalidBirthDate = 'not a valid birth date'
+    expect(isValid('BirthDateReverse', invalidBirthDate)).toBe(false)
+  })
+
+  it('validates no mask', () => {
+    expect(isValid(undefined, 'anything')).toBe(true)
+  })
+})
+
+describe('unmaskValue', () => {
+  it('just returns on no mask', () => {
+    expect(unmaskValue('blah', undefined)).toBe('blah')
+  })
+
+  it('removes dash on PersonalNumber mask', () => {
+    expect(unmaskValue('121212-1212', 'PersonalNumber')).toBe('1212121212')
+  })
+
+  it('removes spaces on PostalCode mask', () => {
+    expect(unmaskValue('123 45', 'PostalCode')).toBe('12345')
+  })
+
+  it('just returns on other masks', () => {
+    expect(unmaskValue('1234', 'NorwegianPostalCode')).toBe('1234')
+    expect(unmaskValue('1923-12-12', 'BirthDate')).toBe('1923-12-12')
+    expect(unmaskValue('12-12-1923', 'BirthDateReverse')).toBe('12-12-1923')
+  })
+})
+
+describe('mapUnmaskedValue', () => {
+  it('maps BirthDateReverse mask from reverse iso date to iso date', () => {
+    expect(mapUnmaskedValue('12-12-1912', 'BirthDateReverse')).toBe(
+      '1912-12-12',
+    )
+  })
+
+  it("doesn't map invalid reverse birth date", () => {
+    expect(mapUnmaskedValue('1234567', 'BirthDateReverse')).toBe('1234567')
+  })
+
+  it("doesn't map other masks", () => {
+    expect(mapUnmaskedValue('1912-12-12', 'BirthDate')).toBe('1912-12-12')
+  })
+})
+
+describe('mapMaskedValue', () => {
+  it('maps BirthDateReverse mask from iso date to reverse iso date', () => {
+    expect(mapMaskedValue('1912-12-12', 'BirthDateReverse')).toBe('12-12-1912')
+  })
+
+  it("doesn't map invalid birth date", () => {
+    expect(mapUnmaskedValue('1234567', 'BirthDateReverse')).toBe('1234567')
+  })
+
+  it("doesn't map other masks", () => {
+    expect(mapUnmaskedValue('1912-12-12', 'BirthDate')).toBe('1912-12-12')
+  })
+})
+
+describe('derivedValues', () => {
+  it('gets age from personal number', () => {
+    expect(derivedValues('PersonalNumber', 'bla', '010101-1212')).toEqual({
+      'bla.Age': new Date().getFullYear() - 2001,
+    })
+  })
+
+  it('gets age from BirthDate', () => {
+    expect(derivedValues('BirthDate', 'bla', '2001-01-01')).toEqual({
+      'bla.Age': new Date().getFullYear() - 2001,
+    })
+    expect(derivedValues('BirthDateReverse', 'bla', '2001-01-01')).toEqual({
+      'bla.Age': new Date().getFullYear() - 2001,
+    })
+  })
+
+  it('gets nothing on other masks', () => {
+    expect(derivedValues('PostalCode', 'bla', '1234')).toBe(null)
+  })
+})

--- a/src/Components/Actions/masking.test.tsx
+++ b/src/Components/Actions/masking.test.tsx
@@ -5,11 +5,11 @@ import {
   mapUnmaskedValue,
   unmaskValue,
 } from './masking'
-import { differenceInYears } from 'date-fns'
+import { differenceInYears, parse } from 'date-fns'
 
 describe('isValid', () => {
   it('validates PersonalNumber mask', () => {
-    const validPersonalNumber = '121212-1212'
+    const validPersonalNumber = '120130-1212'
     expect(isValid('PersonalNumber', validPersonalNumber)).toBe(true)
     const invalidPersonalNumber = 'not a valid personal number'
     expect(isValid('PersonalNumber', invalidPersonalNumber)).toBe(false)
@@ -37,14 +37,14 @@ describe('isValid', () => {
   })
 
   it('validates BirthDate mask', () => {
-    const validBirthDate = '1912-12-12'
+    const validBirthDate = '1912-01-30'
     expect(isValid('BirthDate', validBirthDate)).toBe(true)
     const invalidBirthDate = 'not a valid birth date'
     expect(isValid('BirthDate', invalidBirthDate)).toBe(false)
   })
 
   it('validates BirthDateReverse mask', () => {
-    const validBirthDate = '12-12-1912'
+    const validBirthDate = '30-01-1912'
     expect(isValid('BirthDateReverse', validBirthDate)).toBe(true)
     const invalidBirthDate = 'not a valid birth date'
     expect(isValid('BirthDateReverse', invalidBirthDate)).toBe(false)
@@ -61,7 +61,7 @@ describe('unmaskValue', () => {
   })
 
   it('removes dash on PersonalNumber mask', () => {
-    expect(unmaskValue('121212-1212', 'PersonalNumber')).toBe('1212121212')
+    expect(unmaskValue('120130-1212', 'PersonalNumber')).toBe('1201301212')
   })
 
   it('removes spaces on PostalCode mask', () => {
@@ -70,15 +70,15 @@ describe('unmaskValue', () => {
 
   it('just returns on other masks', () => {
     expect(unmaskValue('1234', 'NorwegianPostalCode')).toBe('1234')
-    expect(unmaskValue('1923-12-12', 'BirthDate')).toBe('1923-12-12')
-    expect(unmaskValue('12-12-1923', 'BirthDateReverse')).toBe('12-12-1923')
+    expect(unmaskValue('1923-01-30', 'BirthDate')).toBe('1923-01-30')
+    expect(unmaskValue('30-01-1923', 'BirthDateReverse')).toBe('30-01-1923')
   })
 })
 
 describe('mapUnmaskedValue', () => {
   it('maps BirthDateReverse mask from reverse iso date to iso date', () => {
-    expect(mapUnmaskedValue('12-12-1912', 'BirthDateReverse')).toBe(
-      '1912-12-12',
+    expect(mapUnmaskedValue('30-01-1912', 'BirthDateReverse')).toBe(
+      '1912-01-30',
     )
   })
 
@@ -87,13 +87,13 @@ describe('mapUnmaskedValue', () => {
   })
 
   it("doesn't map other masks", () => {
-    expect(mapUnmaskedValue('1912-12-12', 'BirthDate')).toBe('1912-12-12')
+    expect(mapUnmaskedValue('1912-01-30', 'BirthDate')).toBe('1912-01-30')
   })
 })
 
 describe('mapMaskedValue', () => {
   it('maps BirthDateReverse mask from iso date to reverse iso date', () => {
-    expect(mapMaskedValue('1912-12-12', 'BirthDateReverse')).toBe('12-12-1912')
+    expect(mapMaskedValue('1912-01-30', 'BirthDateReverse')).toBe('30-01-1912')
   })
 
   it("doesn't map invalid birth date", () => {
@@ -101,23 +101,32 @@ describe('mapMaskedValue', () => {
   })
 
   it("doesn't map other masks", () => {
-    expect(mapUnmaskedValue('1912-12-12', 'BirthDate')).toBe('1912-12-12')
+    expect(mapUnmaskedValue('1912-01-30', 'BirthDate')).toBe('1912-01-30')
   })
 })
 
 describe('derivedValues', () => {
   it('gets age from personal number', () => {
-    expect(derivedValues('PersonalNumber', 'bla', '010101-1212')).toEqual({
-      'bla.Age': new Date().getFullYear() - 2001,
+    expect(derivedValues('PersonalNumber', 'bla', '010203-1212')).toEqual({
+      'bla.Age': differenceInYears(
+        new Date(),
+        parse('2001-02-03', 'yyyy-MM-dd', 0),
+      ),
     })
   })
 
   it('gets age from BirthDate', () => {
-    expect(derivedValues('BirthDate', 'bla', '2001-01-01')).toEqual({
-      'bla.Age': new Date().getFullYear() - 2001,
+    expect(derivedValues('BirthDate', 'bla', '2001-02-03')).toEqual({
+      'bla.Age': differenceInYears(
+        new Date(),
+        parse('2001-02-03', 'yyyy-MM-dd', 0),
+      ),
     })
-    expect(derivedValues('BirthDateReverse', 'bla', '2001-01-01')).toEqual({
-      'bla.Age': new Date().getFullYear() - 2001,
+    expect(derivedValues('BirthDateReverse', 'bla', '2001-02-03')).toEqual({
+      'bla.Age': differenceInYears(
+        new Date(),
+        parse('2001-02-03', 'yyyy-MM-dd', 0),
+      ),
     })
   })
 

--- a/src/Components/Actions/masking.tsx
+++ b/src/Components/Actions/masking.tsx
@@ -128,11 +128,7 @@ export const derivedValues = (
   }
 
   if (mask === 'BirthDate' || mask === 'BirthDateReverse') {
-    const dateOfBirth = parse(
-      value,
-      mask === 'BirthDateReverse' ? 'dd-MM-yyyy' : 'yyyy-MM-dd',
-      0,
-    )
+    const dateOfBirth = parse(value, 'yyyy-MM-dd', 0)
 
     return {
       [`${key}.Age`]: differenceInYears(new Date(), dateOfBirth),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5915,7 +5915,7 @@ raw-body@^2.3.3:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.10.2:
+react-dom@^16.13.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -5962,7 +5962,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react@^16.11.0:
+react@^16.13.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
Since `BirthDateReverse` is "unmasked" before its passed to `derivedValues` it is always in iso format when it arrives there.