### PR TITLE
Allow `customData` to be null

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -355,7 +355,7 @@ const typeDefs = `
         eventName: String!
         eventKeys: [String]!
         includeAllKeys: Boolean!
-        customData: JSONString!
+        customData: JSONString
     }
 
     enum EmbarkExpressionTypeMultiple {


### PR DESCRIPTION
This aligns the schema with reality, as `customData` is not required to be specified.