### PR TITLE
Parse date picker action and add to schema

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -279,6 +279,14 @@ const typeDefs = `
         component: String!
         data: EmbarkMultiActionData!
     }
+    
+    type EmbarkDatePickerAction implements EmbarkActionCore {
+        component: String!       
+        next: EmbarkLink!
+        storeKey: String!
+        label: String!
+        tooltip: EmbarkTooltip
+    }
 
     type EmbarkDropdownOption {
         value: String!
@@ -307,7 +315,15 @@ const typeDefs = `
         data: EmbarkSwitchActionData!
     }
 
-    union EmbarkAction = EmbarkExternalInsuranceProviderAction | EmbarkPreviousInsuranceProviderAction | EmbarkNumberActionSet | EmbarkTextActionSet | EmbarkTextAction | EmbarkSelectAction | EmbarkNumberAction | EmbarkMultiAction
+    union EmbarkAction = EmbarkExternalInsuranceProviderAction | 
+        EmbarkPreviousInsuranceProviderAction | 
+        EmbarkNumberActionSet | 
+        EmbarkTextActionSet | 
+        EmbarkTextAction | 
+        EmbarkSelectAction | 
+        EmbarkNumberAction | 
+        EmbarkMultiAction |
+        EmbarkDatePickerAction
 
     union EmbarkMultiActionComponent = EmbarkNumberAction | EmbarkDropdownAction | EmbarkSwitchAction
 

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -385,6 +385,24 @@ const getPreviousInsuranceProviderAction = (
   }
 }
 
+const getDatePickerAction = (node: Element, translate: Translator) => {
+  const next = translate(node.getAttribute('next') || '')
+  const nextLinks = next ? parseLinks(next) : []
+
+  const storeKey = translate(node.getAttribute('storeKey') || '')
+  const label = translate(node.getAttribute('label') || '')
+  const tooltip = parseTooltips(node, translate)[0]
+
+  return {
+    __typename: 'EmbarkDatePickerAction',
+    component: 'DatePickerActions',
+    next: nextLinks && nextLinks[0],
+    storeKey,
+    label,
+    ...(tooltip && { tooltip }),
+  }
+}
+
 const getAction = (containerElement: Element, translate: Translator) => {
   const numberActionSetNode = containerElement.getElementsByTagName(
     'numberactionset',
@@ -452,6 +470,14 @@ const getAction = (containerElement: Element, translate: Translator) => {
       previousInsuranceProviderActionNode,
       translate,
     )
+  }
+
+  const datePickerActionNode = containerElement.getElementsByTagName(
+    'datepickeraction',
+  )[0]
+
+  if (datePickerActionNode) {
+    return getDatePickerAction(datePickerActionNode, translate)
   }
 
   return null

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -395,7 +395,7 @@ const getDatePickerAction = (node: Element, translate: Translator) => {
 
   return {
     __typename: 'EmbarkDatePickerAction',
-    component: 'DatePickerActions',
+    component: 'DatePickerAction',
     next: nextLinks && nextLinks[0],
     storeKey,
     label,


### PR DESCRIPTION
This action is used in the moving flow (changing a contract to another address) for selecting a move in date.