### PR TITLE
[GRW-12] Remove computedStoreValues as a prop on EmbarkProvider

### DIFF
--- a/src/Components/EmbarkProvider.tsx
+++ b/src/Components/EmbarkProvider.tsx
@@ -21,6 +21,15 @@ interface EmbarkProviderProps {
   initialStore?: Store
 }
 
+const mapComputedStoreValuesList = (
+  computedStoreValues: ReadonlyArray<ComputedStoreValues> | undefined,
+) => {
+  return computedStoreValues?.reduce(
+    (acc, { key, value }) => ({ ...acc, [key]: value }),
+    {},
+  )
+}
+
 const StoreListener: React.FunctionComponent<EmbarkProviderProps> = (props) => {
   const { store } = React.useContext(StoreContext)
 
@@ -34,21 +43,6 @@ const StoreListener: React.FunctionComponent<EmbarkProviderProps> = (props) => {
 export const EmbarkProvider: React.FunctionComponent<EmbarkProviderProps> = (
   props,
 ) => {
-  const [computedStoreValues, setComputedStoreValues] = useState<
-    ComputedStoreValues
-  >({})
-
-  useEffect(() => {
-    if (props.data.computedStoreValues) {
-      const parsedComputedStoreValues = (props.data
-        .computedStoreValues as ReadonlyArray<ComputedStoreValues>).reduce(
-        (acc, { key, value }) => ({ ...acc, [key]: value }),
-        {},
-      )
-      setComputedStoreValues(parsedComputedStoreValues)
-    }
-  }, [props.data.computedStoreValues])
-
   return (
     <ExternalRedirectContext.Provider value={props.externalRedirects}>
       <ApiContext.Provider value={props.resolvers}>
@@ -56,7 +50,9 @@ export const EmbarkProvider: React.FunctionComponent<EmbarkProviderProps> = (
           <KeywordsContext.Provider value={props.data.keywords}>
             <KeyValueStore
               initial={props.initialStore}
-              computedStoreValues={computedStoreValues}
+              computedStoreValues={mapComputedStoreValuesList(
+                props.data.computedStoreValues,
+              )}
             >
               <StoreListener {...props}>{props.children}</StoreListener>
             </KeyValueStore>

--- a/src/Components/EmbarkProvider.tsx
+++ b/src/Components/EmbarkProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   ComputedStoreValues,
   KeyValueStore,
@@ -19,7 +19,6 @@ interface EmbarkProviderProps {
   externalRedirects: TExternalRedirectContext
   onStoreChange?: (store: Store) => void
   initialStore?: Store
-  computedStoreValues?: ComputedStoreValues
 }
 
 const StoreListener: React.FunctionComponent<EmbarkProviderProps> = (props) => {
@@ -34,19 +33,36 @@ const StoreListener: React.FunctionComponent<EmbarkProviderProps> = (props) => {
 
 export const EmbarkProvider: React.FunctionComponent<EmbarkProviderProps> = (
   props,
-) => (
-  <ExternalRedirectContext.Provider value={props.externalRedirects}>
-    <ApiContext.Provider value={props.resolvers}>
-      <DataFetchContextProvider>
-        <KeywordsContext.Provider value={props.data.keywords}>
-          <KeyValueStore
-            initial={props.initialStore}
-            computedStoreValues={props.computedStoreValues}
-          >
-            <StoreListener {...props}>{props.children}</StoreListener>
-          </KeyValueStore>
-        </KeywordsContext.Provider>
-      </DataFetchContextProvider>
-    </ApiContext.Provider>
-  </ExternalRedirectContext.Provider>
-)
+) => {
+  const [computedStoreValues, setComputedStoreValues] = useState<
+    ComputedStoreValues
+  >({})
+
+  useEffect(() => {
+    if (props.data.computedStoreValues) {
+      const parsedComputedStoreValues = (props.data
+        .computedStoreValues as ReadonlyArray<ComputedStoreValues>).reduce(
+        (acc, { key, value }) => ({ ...acc, [key]: value }),
+        {},
+      )
+      setComputedStoreValues(parsedComputedStoreValues)
+    }
+  }, [props.data.computedStoreValues])
+
+  return (
+    <ExternalRedirectContext.Provider value={props.externalRedirects}>
+      <ApiContext.Provider value={props.resolvers}>
+        <DataFetchContextProvider>
+          <KeywordsContext.Provider value={props.data.keywords}>
+            <KeyValueStore
+              initial={props.initialStore}
+              computedStoreValues={computedStoreValues}
+            >
+              <StoreListener {...props}>{props.children}</StoreListener>
+            </KeyValueStore>
+          </KeywordsContext.Provider>
+        </DataFetchContextProvider>
+      </ApiContext.Provider>
+    </ExternalRedirectContext.Provider>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useEffect, useState } from 'react'
 import * as ReactDOM from 'react-dom'
 import { Passage } from './Components/Passage'
 import { Proofing } from './Components/Proofing'
@@ -102,9 +102,9 @@ const Root = () => {
     )
   }
 
-  const [urlParams, setUrlParams] = React.useState<URLSearchParams | null>(null)
+  const [urlParams, setUrlParams] = useState<URLSearchParams | null>(null)
 
-  React.useEffect(() => {
+  useEffect(() => {
     setUrlParams(new URLSearchParams(window.location.search))
   }, [])
 
@@ -177,12 +177,6 @@ const RootContainer = () => (
     onStoreChange={(store) => {
       console.log('store changed', store)
     }}
-    computedStoreValues={(data.computedStoreValues as
-      | ReadonlyArray<{ key: string; value: string }>
-      | undefined)?.reduce<Record<string, string>>(
-      (acc, { key, value }) => ({ ...acc, [key]: value }),
-      {},
-    )}
   >
     <Root />
   </EmbarkProvider>


### PR DESCRIPTION
## What
Remove computedStoreValues as a prop on EmbarkProvider. This was the reason it didn't work in the web-onbarding where we didn't send it in as a prop in the `<EmbarkProvider>`.

## Why
To remove the risk of implementing this and forgetting to add the `computedStoreValues` prop (since it's derived from the data object anyway). It feels easier to encapsulate it it the actual component instead.

👍 or 👎