### PR TITLE
Add OfferRedirect concept

### DIFF
--- a/angel-data/Web Onboarding NO - English Combo.json
+++ b/angel-data/Web Onboarding NO - English Combo.json
@@ -70,7 +70,7 @@
       "selected": false,
       "story": "-1503132176",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"norwegianHomeContentsQuoteId,norwegianTravelQuoteId\">\n</OfferRedirect>",
       "top": 1750,
       "width": 100
     },

--- a/angel-data/Web Onboarding NO - English Contents.json
+++ b/angel-data/Web Onboarding NO - English Contents.json
@@ -8,9 +8,7 @@
     "tooltipModalInformationLabel": "Information"
   },
   "lastUpdate": "2021-02-10T08:46:48.944Z",
-  "locales": [
-    "en_NO"
-  ],
+  "locales": ["en_NO"],
   "metadata": [
     {
       "description": "NORWAY_CONTENTS_APP_METADATA_DESCRIPTION",
@@ -46,7 +44,7 @@
       "selected": false,
       "story": "1392201379",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"quoteId\">\n</OfferRedirect>",
       "top": 1375,
       "width": 100
     },
@@ -121,9 +119,7 @@
       "name": "errorNumberCoInsured",
       "selected": false,
       "story": "1392201379",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Unfortunately, we can only insure homes with a maximum of 6 people\n</Message>\n\n<Message>\n  If you want to, you can subscribe to our newsletter to be the first to know when we can insure homes with more than 6 people!\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Yes, subscribe to the newsletter->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 650,
       "url": "/error",
@@ -136,9 +132,7 @@
       "name": "errorSize",
       "selected": false,
       "story": "1392201379",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Unfortunately we can currently only insure residences up to 250 square meters\n</Message>\n\n<Message>\n  If you want to, you can subscribe to our newsletter to be the first to know when we are able to insure residences in your size\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Yes, subscribe to the newsletter->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 500,
       "url": "/error",

--- a/angel-data/Web Onboarding NO - English Travel.json
+++ b/angel-data/Web Onboarding NO - English Travel.json
@@ -8,9 +8,7 @@
     "tooltipModalInformationLabel": "Information"
   },
   "lastUpdate": "2021-02-04T08:27:55.241Z",
-  "locales": [
-    "en_NO"
-  ],
+  "locales": ["en_NO"],
   "metadata": [
     {
       "description": "NORWAY_TRAVEL_APP_METADATA_DESCRIPTION",
@@ -59,7 +57,7 @@
       "selected": false,
       "story": "830193891",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"quoteId\">\n</OfferRedirect>",
       "top": 1450,
       "width": 100
     },
@@ -70,9 +68,7 @@
       "name": "errorSize",
       "selected": false,
       "story": "830193891",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Unfortunately, we can only insure homes with a maximum of 6 people\n</Message>\n\n<Message>\n  If you want to, you can subscribe to our newsletter to be the first to know when we can insure more than 6 people!\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Yes, subscribe to the newsletter->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 950,
       "url": "/error",

--- a/angel-data/Web Onboarding NO - Norwegian Combo.json
+++ b/angel-data/Web Onboarding NO - Norwegian Combo.json
@@ -8,9 +8,7 @@
     "tooltipModalInformationLabel": "Informasjon"
   },
   "lastUpdate": "2021-03-09T13:39:26.412Z",
-  "locales": [
-    "nb_NO"
-  ],
+  "locales": ["nb_NO"],
   "metadata": [
     {
       "description": "NORWAY_COMBO_APP_METADATA_DESCRIPTION",
@@ -122,9 +120,7 @@
       "name": "errorCoInsured",
       "selected": false,
       "story": "-1676947869",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Dessverre kan vi bare forsikre hjem med maks 6 personer\n</Message>\n\n<Message>\n  Meld deg gjerne på vårt nyhetsbrev, så blir du blant de første som får vite det når vi kan forsikre hjem med flere enn 6 personer!\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Ja, jeg vil gjerne motta nyhetsbrev->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 1250,
       "url": "/error",
@@ -138,7 +134,7 @@
       "selected": false,
       "story": "-1676947869",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"norwegianHomeContentsQuoteId,norwegianTravelQuoteId\">\n</OfferRedirect>",
       "top": 1750,
       "width": 100
     },
@@ -200,9 +196,7 @@
       "name": "errorSize",
       "selected": false,
       "story": "-1676947869",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Dessverre kan vi foreløpig bare forsikre boliger opp til 250 kvadratmeter\n</Message>\n\n<Message>\n  Meld deg gjerne på vårt nyhetsbrev, så blir du blant de første som får vite det når vi kan forsikre boliger i den størrelsen du har.\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Ja, jeg vil gjerne motta nyhetsbrev->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 1100,
       "url": "/error",

--- a/angel-data/Web Onboarding NO - Norwegian Contents.json
+++ b/angel-data/Web Onboarding NO - Norwegian Contents.json
@@ -8,9 +8,7 @@
     "tooltipModalInformationLabel": "Informasjon"
   },
   "lastUpdate": "2021-03-09T13:47:26.769Z",
-  "locales": [
-    "nb_NO"
-  ],
+  "locales": ["nb_NO"],
   "metadata": [
     {
       "description": "NORWAY_CONTENTS_APP_METADATA_DESCRIPTION",
@@ -71,7 +69,7 @@
       "selected": false,
       "story": "1150685733",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"quoteId\">\n</OfferRedirect>",
       "top": 1375,
       "width": 100
     },
@@ -82,9 +80,7 @@
       "name": "errorNumberCoInsured",
       "selected": false,
       "story": "1150685733",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Dessverre kan vi bare forsikre hjem med maks 6 personer\n</Message>\n\n<Message>\n  Meld deg gjerne på vårt nyhetsbrev, så blir du blant de første som får vite det når vi kan forsikre hjem med flere enn 6 personer!\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Ja, jeg vil gjerne motta nyhetsbrev->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 650,
       "url": "/error",
@@ -187,9 +183,7 @@
       "name": "errorSize",
       "selected": false,
       "story": "1150685733",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Dessverre kan vi foreløpig bare forsikre boliger opp til 250 kvadratmeter\n</Message>\n\n<Message>\n  Meld deg gjerne på vårt nyhetsbrev, så blir du blant de første som får vite det når vi kan forsikre boliger i den størrelsen du har\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Ja, jeg vil gjerne motta nyhetsbrev->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 500,
       "url": "/error",

--- a/angel-data/Web Onboarding NO - Norwegian Travel.json
+++ b/angel-data/Web Onboarding NO - Norwegian Travel.json
@@ -8,9 +8,7 @@
     "tooltipModalInformationLabel": "Informasjon"
   },
   "lastUpdate": "2021-03-23T10:52:49.920Z",
-  "locales": [
-    "nb_NO"
-  ],
+  "locales": ["nb_NO"],
   "metadata": [
     {
       "description": "NORWAY_TRAVEL_APP_METADATA_DESCRIPTION",
@@ -109,9 +107,7 @@
       "name": "errorSize",
       "selected": false,
       "story": "43351269",
-      "tags": [
-        "Error"
-      ],
+      "tags": ["Error"],
       "text": "<Message>\n  Dessverre kan vi bare forsikre maks 6 personer\n</Message>\n\n<Message>\n  Meld deg gjerne på vårt nyhetsbrev, så blir du blant de første som får vite det når vi kan forsikre hjem med flere enn 6 personer!\n</Message>\n\n<SelectAction>\n  <Option>\n    [[Ja, jeg vil gjerne motta nyhetsbrev->NewsletterSuccess]]\n  </Option>\n</SelectAction>",
       "top": 950,
       "url": "/error",
@@ -125,7 +121,7 @@
       "selected": false,
       "story": "43351269",
       "tags": [],
-      "text": "<ExternalRedirect to=\"Offer\">\n</ExternalRedirect>",
+      "text": "<OfferRedirect keys=\"quoteId\">\n</OfferRedirect>",
       "top": 1450,
       "width": 100
     },

--- a/schema.ts
+++ b/schema.ts
@@ -152,6 +152,15 @@ const typeDefs = `
         location: EmbarkExternalRedirectLocation!
     }
 
+    type EmbarkOfferRedirect {
+        component: String!
+        data: EmbarkOfferRedirectData!
+    }
+
+    type EmbarkOfferRedirectData {
+        keys: [String]!
+    }
+
     enum EmbarkExternalRedirectLocation {
         MailingList
         Offer
@@ -360,6 +369,7 @@ const typeDefs = `
         api: EmbarkApi
         messages: [EmbarkMessage!]!
         externalRedirect: EmbarkExternalRedirect
+        offerRedirect: EmbarkOfferRedirect
         action: EmbarkAction
         response: EmbarkResponse!
         tooltips: [EmbarkTooltip!]!

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -46,6 +46,27 @@ const parseExternalRedirect = (containerElement: Element) => {
   }
 }
 
+/*
+<OfferRedirect keys="key1, key2"></OfferRedirect>
+*/
+
+const parseOfferRedirect = (containerElement: Element) => {
+  const node = containerElement.getElementsByTagName('OfferRedirect')[0]
+
+  if (!node) {
+    return null
+  }
+
+  const keys = node.getAttribute('keys')?.split(',') || []
+
+  return {
+    component: 'OfferRedirect',
+    data: {
+      keys,
+    },
+  }
+}
+
 const getPotentiallyMultipleItemsFromKeyOrValue = (
   keyOrValue: string | null,
   translate: Translator = (str) => str,
@@ -948,6 +969,7 @@ export const parseStoryData = (storyData: any, textKeyMap: TextKeyObject) => {
         .filter((item) => item)
 
       const externalRedirect = parseExternalRedirect(containerElement)
+      const offerRedirect = parseOfferRedirect(containerElement)
 
       return {
         id: passage.id,
@@ -969,6 +991,7 @@ export const parseStoryData = (storyData: any, textKeyMap: TextKeyObject) => {
         messages,
         redirects,
         externalRedirect,
+        offerRedirect,
         action: getAction(containerElement, translate),
         response: getResponse(
           passage.name,

--- a/src/Utils/ExpressionsUtil/useGoTo.ts
+++ b/src/Utils/ExpressionsUtil/useGoTo.ts
@@ -62,6 +62,16 @@ export const useGoTo = (
         return
       }
 
+      if (newPassage.offerRedirect) {
+        track('Offer Redirect', {})
+        setGoTo(null)
+        const quoteIds = newPassage.offerRedirect.keys.map(
+          (key: string) => store[key],
+        )
+        externalRedirectContext.Offer(quoteIds)
+        return
+      }
+
       onGoTo(targetPassage)
     }
 

--- a/src/Utils/useEmbark.ts
+++ b/src/Utils/useEmbark.ts
@@ -17,7 +17,7 @@ const shouldBeAddedToHistory = (passage: any) => {
     return false
   }
 
-  if (passage.externalRedirect) {
+  if (passage.externalRedirect || passage.offerRedirect) {
     return false
   }
 

--- a/src/externalRedirect.ts
+++ b/src/externalRedirect.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 export interface TExternalRedirectContext {
-  Offer: () => void
+  Offer: (ids: string[]) => void
   MailingList: () => void
 }
 
@@ -31,7 +31,7 @@ export const performExternalRedirect = (
   externalRedirect: ExternalRedirect,
 ) => {
   if (externalRedirect.data.location === 'Offer') {
-    context.Offer()
+    context.Offer([])
   }
 
   if (externalRedirect.data.location === 'MailingList') {


### PR DESCRIPTION
This makes it possible for the embark client to know which quote ids to fetch from the store and pass on to the offer screen, allowing us to not have to hard code this behavior in the apps.

For web I made it so that `ExternalRedirectContext` now gets an argument of the ids when the `Offer` function is called, nothing has to be changed on the web side of things as this change is backwards compatible, but it could be worth changing the logic which figures out which offers to show after redirecting on web-onboarding down the line to keep behaviour predictable across app and web.