### PR TITLE
Deprecate returning `EmbarkMessage` from `EmbarkResponse`

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -368,6 +368,7 @@ const typeDefs = `
         expressions: [EmbarkExpression!]!
     }
 
+    # Returning EmbarkMessage from EmbarkResponse is deprecated and will be removed in a future version.
     union EmbarkResponse = EmbarkGroupedResponse | EmbarkResponseExpression | EmbarkMessage
 
     type EmbarkTooltip {

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -709,7 +709,7 @@ const getResponse = (
   }
 
   return {
-    __typename: 'EmbarkMessage',
+    __typename: 'EmbarkResponseExpression',
     expressions: [],
     text: `{${passageName}Result}`,
   }


### PR DESCRIPTION
They are entirely equivalent. Might as well only have one
