### PR TITLE
Make sure long placeholders don't make the input filed too wide

### DIFF
--- a/src/Components/Actions/InlineActions/InlineTextAction.tsx
+++ b/src/Components/Actions/InlineActions/InlineTextAction.tsx
@@ -39,11 +39,14 @@ interface Props {
 
 const Masked = wrapWithMask(Input)
 
-const getInputSize = (exampleValue: string, value: string, large?: 'true') =>
-  Math.max(
+const getInputSize = (exampleValue: string, value: string, large?: 'true') => {
+  const maximumInputSize = 34
+  const calculatedInputSize = Math.max(
     large === 'true' ? exampleValue.length * 2 : exampleValue.length,
     value.length,
   )
+  return Math.min(calculatedInputSize, maximumInputSize)
+}
 
 export const InlineTextAction: React.FunctionComponent<Props> = (props) => {
   const size = getInputSize(


### PR DESCRIPTION
When adding a longer placeholder for address field, the input calculation got too wide. Set a max size so it doesn't become too large, the content will still scroll if it's a super duper long address

**Without max size**
![Screenshot 2021-04-28 at 15 15 23](https://user-images.githubusercontent.com/6661511/116410243-dded1500-a834-11eb-8b1d-6eceb41a7f0a.png)

**With max size**
![Screenshot 2021-04-28 at 15 15 42](https://user-images.githubusercontent.com/6661511/116410278-e5142300-a834-11eb-8eec-d1426848c948.png)
