### PR TITLE
Add missing values to schema for EmbarkMultiActionData

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -296,6 +296,10 @@ const typeDefs = `
     }
 
     type EmbarkMultiActionData {
+        key: String
+        addLabel: String
+        maxAmount: String!
+        link: EmbarkLink!
         components: [EmbarkMultiActionComponent!]!
     }
 


### PR DESCRIPTION
These are returned in `parseStoryData.ts`: 
```
return {
    __typename: 'EmbarkMultiAction',
    component: 'MultiAction',
    data: {
      key,
      addLabel,
      components,
      maxAmount,
      api,
      link: links && links[0],
    },
  }
```
But not included in `schema.ts`. We need to be able to query these from the apps. 