### PR TITLE
Fix schema being incorrect wrt. `EmbarkGroupedResponse.each`

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -364,7 +364,7 @@ const typeDefs = `
         component: String!
         title: EmbarkResponseExpression!
         items: [EmbarkMessage!]!
-        each: [EmbarkGroupedResponseEach!]!
+        each: EmbarkGroupedResponseEach
     }
 
     type EmbarkResponseExpression {

--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -746,7 +746,7 @@ const parseGroupedResponse = (
       ...parsePossibleExpressionContent(title),
     },
     items: items.map(parsePossibleExpressionContent),
-    each: (each && parseEach(each, parsePossibleExpressionContent)) || [],
+    each: each && parseEach(each, parsePossibleExpressionContent),
   }
 }
 


### PR DESCRIPTION
Looks like it's never been used since the schema has been defined. This PR
aligns it with the existing data structure.
