### PR TITLE
Vertically center Hedvig logo

### DIFF
--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -34,6 +34,7 @@ const LogoImage = styled.img`
 
 const Svg = styled.svg`
   fill: currentColor;
+  vertical-align: bottom;
 `
 
 export const HedvigLogo: React.FunctionComponent = () => (


### PR DESCRIPTION
## What

Remove white space from bottom of svg.

## Why

The logo has some white space at the bottom so it doesn't look vertically centered.


https://user-images.githubusercontent.com/1220232/118952941-a87fa700-b95c-11eb-8f32-591fa7898936.mov