### PR TITLE
Change regex used to replace characters in computed values to avoid stripping information from contract bundle ids

### DIFF
--- a/load-story.ts
+++ b/load-story.ts
@@ -12,8 +12,8 @@ export const loadStory = async (name: string, locale: string) => {
       const splittedParam = param.split('=')
 
       return {
-        key: splittedParam[0].replace(/\W/g, ''),
-        value: `'${splittedParam[1].replace(/\W/g, '')}'`,
+        key: splittedParam[0].replace(/\'+/g, ''),
+        value: `'${splittedParam[1].replace(/\'+/g, '')}'`,
       }
     }) || []
 


### PR DESCRIPTION
Bundle ids could not be parsed correctly in giraffe since we stripped "-" from the id. This should fix the issue and still prevent malicious injection.