### PR TITLE
Trim DropdownAction Text

### DIFF
--- a/src/Parsing/parseStoryData.ts
+++ b/src/Parsing/parseStoryData.ts
@@ -175,7 +175,7 @@ const getDropdownAction = (
       value: translate(
         option.getAttribute('value') || option.textContent || '',
       ),
-      text: translate(option.textContent || ''),
+      text: translate(option.textContent || '').trim(),
     }
   })
 


### PR DESCRIPTION
Because the value of text was something like `\n        Other\n      `