### PR TITLE
Fix alignment of `x` symbol in clear button

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
@@ -39,6 +39,8 @@ const ClearButton = styled.button`
   }
 
   svg {
+    display: block;
+    margin: auto;
     width: 60%;
     height: 60%;
   }


### PR DESCRIPTION
Align x-icon in clear button in `AddressAutocompleteAction`.

Preview:

![Screenshot 2021-06-23 at 17 30 55](https://user-images.githubusercontent.com/1220232/123125546-e3d43080-d448-11eb-9ae1-5a6e1427a7b5.png)
