### PR TITLE
Center text in fake input for `AddressAutocompleteAction`

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -7,12 +7,7 @@ import { Cross } from '../../Icons/Cross'
 import Modal from './Modal'
 import Combobox from './Combobox'
 import useAddressSearch from './useAddressSearch'
-import {
-  formatAddressLine,
-  formatAddressLines,
-  formatPostalLine,
-  isMatchingStreetName,
-} from './utils'
+import { formatAddressLine, formatAddressLines } from './utils'
 import { KeywordsContext } from '../../KeywordsContext'
 
 const ADDRESS_NOT_FOUND = 'ADDRESS_NOT_FOUND'
@@ -169,12 +164,6 @@ const AddressAutocomplete: React.FC<Props> = (props) => {
     onClear()
   }, [])
 
-  const pickedPostalLine = selected ? formatPostalLine(selected) : undefined
-  const isMatchingPickedSuggestion = isMatchingStreetName(
-    value,
-    selected ?? undefined,
-  )
-
   return (
     <Modal isOpen={isActive} onDismiss={onDismiss}>
       <ModalHeader>
@@ -194,9 +183,6 @@ const AddressAutocomplete: React.FC<Props> = (props) => {
               placeholder,
             })}
           />
-          {pickedPostalLine && isMatchingPickedSuggestion ? (
-            <PostalAddress>{pickedPostalLine}</PostalAddress>
-          ) : null}
 
           {value.length > 0 ? (
             <Combobox.ClearButton onClick={handleClearInput}>

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -53,8 +53,6 @@ const Card = styled(BaseCard)`
 `
 
 const FakeInput = styled(Input)`
-  width: 100%;
-  text-align: left;
   margin-left: 0;
   margin-right: 0;
   padding: 0 16px;
@@ -70,7 +68,7 @@ const FakeInput = styled(Input)`
 const PostalAddress = styled.p`
   font-family: ${fonts.FAVORIT}, sans-serif;
   font-size: 16px;
-  text-align: left;
+  text-align: center;
   color: ${colorsV3.gray700};
   margin: 0;
   padding-left: 16px;

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -71,11 +71,9 @@ const PostalAddress = styled.p`
   text-align: center;
   color: ${colorsV3.gray700};
   margin: 0;
-  padding-left: 16px;
 
   @media (min-width: 600px) {
     font-size: 24px;
-    padding-left: 32px;
   }
 `
 


### PR DESCRIPTION
## What?

Make sure placeholder fits in input.
Remove second line (postal) in autocomplete input.

## Why?

Text should be centered in input in chat flow.

## Preview

Empty input with centered placeholder text.

![Screenshot 2021-06-23 at 17 27 30](https://user-images.githubusercontent.com/1220232/123125862-31e93400-d449-11eb-90ca-9ba6f424189e.png)

![Screenshot 2021-06-23 at 17 27 37](https://user-images.githubusercontent.com/1220232/123125872-3281ca80-d449-11eb-891f-9a1e18b351a0.png)

Confirmed/complete address displayed with centered text

![Screenshot 2021-06-23 at 17 28 43](https://user-images.githubusercontent.com/1220232/123126013-52b18980-d449-11eb-96d7-5e213b01e64e.png)

![Screenshot 2021-06-23 at 17 28 03](https://user-images.githubusercontent.com/1220232/123126008-5218f300-d449-11eb-87cc-d22295ef977a.png)

Address autocomplete input without second postal line

![Screenshot 2021-06-23 at 17 28 12](https://user-images.githubusercontent.com/1220232/123126401-a58b4100-d449-11eb-9b73-335ed7251dce.png)