### PR TITLE
Set a larger touch target for autocomplete items

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
@@ -77,9 +77,10 @@ const ComboboxInput = styled.input`
 
 const ComboboxOption = styled.li`
   padding: 8px 16px;
-  min-height: 32px;
+  min-height: 48px;
   display: flex;
   align-items: center;
+  box-sizing: border-box;
 
   text-align: left;
   font-family: ${fonts.FAVORIT}, sans-serif;


### PR DESCRIPTION
## What 
Larger autocomplete list items 

## Why
It looked good in Chrome but not in iOS Safari since we don't have a global `box-sizing` rule in embark 😄

### Before
<img src="https://user-images.githubusercontent.com/6661511/123290962-f8c8c680-d511-11eb-82de-22103d64628d.PNG" width="400" />

### After
<img src="https://user-images.githubusercontent.com/6661511/123290981-fd8d7a80-d511-11eb-98ab-86eddfb1ba0d.PNG" width="400" />
