### PR TITLE
Fix formatting of address line

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/useAddressSearch.ts
+++ b/src/Components/Actions/AddressAutocompleteAction/useAddressSearch.ts
@@ -11,9 +11,13 @@ const getApiQuery = (searchTerm: string, suggestion?: AddressSuggestion) => {
       return searchTerm + ' '
     }
 
-    if (suggestion.postalCode && isMatchingStreetName(searchTerm, suggestion)) {
+    if (
+      suggestion.city &&
+      suggestion.postalCode &&
+      isMatchingStreetName(searchTerm, suggestion)
+    ) {
       // Refine search after selecting a specific building (floor & apartment)
-      return `${searchTerm} ${suggestion.postalCode} ${suggestion.city}`
+      return `${searchTerm}, , ${suggestion.postalCode} ${suggestion.city}`
     }
   }
 

--- a/src/Components/Actions/AddressAutocompleteAction/utils.ts
+++ b/src/Components/Actions/AddressAutocompleteAction/utils.ts
@@ -3,19 +3,20 @@ import {
   CompleteAddress,
 } from '../../API/addressAutocomplete'
 
-export const formatAddressLine = (address: AddressSuggestion): string => {
-  if (address.streetName && address.streetNumber) {
-    let displayAddress = `${address.streetName} ${address.streetNumber}`
-    if (address.floor) {
-      displayAddress += `, ${address.floor}.`
-    }
-    if (address.apartment) {
-      displayAddress += ` ${address.apartment}`
-    }
-    return displayAddress
+export const formatAddressLine = (suggestion: AddressSuggestion): string => {
+  if (
+    suggestion.city &&
+    suggestion.postalCode &&
+    suggestion.streetName &&
+    suggestion.streetNumber
+  ) {
+    return suggestion.address
+      .replace(suggestion.city, '')
+      .replace(suggestion.postalCode, '')
+      .replace(/,\s*$/, '')
   }
 
-  return address.address
+  return suggestion.address
 }
 
 export const formatPostalLine = (
@@ -38,7 +39,10 @@ export const isMatchingStreetName = (
   searchTerm: string,
   suggestion?: AddressSuggestion,
 ) => {
-  return suggestion?.streetName && searchTerm.startsWith(suggestion.streetName)
+  if (suggestion) {
+    return searchTerm.startsWith(formatAddressLine(suggestion))
+  }
+  return false
 }
 
 const MANDATORY_ADDRESS_FIELDS: Array<keyof AddressSuggestion> = [


### PR DESCRIPTION
Update API query to limit search on apartment + floor.
Street name is sometimes abbreviated so need to use address field.


https://user-images.githubusercontent.com/1220232/123637479-5c0e6d80-d81e-11eb-8f1e-e7b2d32a9e88.mov

