### PR TITLE
Avoid cursor jumping in input field

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -132,35 +132,26 @@ const AddressAutocomplete: React.FC<Props> = (props) => {
     getComboboxProps,
     highlightedIndex,
     getItemProps,
+    reset,
   } = useCombobox<AddressSuggestion>({
-    selectedItem: selected,
     inputValue: value,
     items: comboboxItems,
-    itemToString: (item) => (item ? formatAddressLine(item) : ''),
-    onInputValueChange: ({ inputValue, type }) => {
-      if (type === '__input_keydown_escape__') return
-
-      onChange(inputValue || '')
-
-      if (!inputValue) {
-        // Reset picked suggestion for empty input field
-        onSelect(null)
-      }
-    },
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem?.address === ADDRESS_NOT_FOUND) {
         onNotFound()
+      } else {
+        onSelect(selectedItem ?? null)
       }
 
       // Reset list of suggestions
       setSuggestions(null)
       inputRef.current?.focus()
-      onSelect(selectedItem ?? null)
     },
   })
 
   const handleClearInput = React.useCallback(() => {
     inputRef.current?.focus()
+    reset()
     onClear()
   }, [])
 
@@ -181,6 +172,8 @@ const AddressAutocomplete: React.FC<Props> = (props) => {
             {...getInputProps({
               ref: inputRef,
               placeholder,
+              onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+                onChange(event.target.value),
             })}
           />
 

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -7,7 +7,7 @@ import { Cross } from '../../Icons/Cross'
 import Modal from './Modal'
 import Combobox from './Combobox'
 import useAddressSearch from './useAddressSearch'
-import { formatAddressLine, formatAddressLines } from './utils'
+import { formatAddressLines } from './utils'
 import { KeywordsContext } from '../../KeywordsContext'
 
 const ADDRESS_NOT_FOUND = 'ADDRESS_NOT_FOUND'

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -175,6 +175,7 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
       setPickedSuggestion(suggestion)
 
       if (suggestion) {
+        setSearchTerm(formatAddressLine(suggestion))
         setConfirmedAddress(
           await confirmSuggestion(suggestion, pickedSuggestion),
         )
@@ -186,6 +187,12 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
   const handleChangeInput = React.useCallback(
     (newValue: string) => {
       setSearchTerm(newValue)
+
+      // Reset picked suggestion for empty input field
+      if (!newValue) {
+        setPickedSuggestion(null)
+      }
+
       setConfirmedAddress((prevValue) => {
         // Reset confirmed address unless it matches the updated search term
         if (prevValue && newValue !== formatAddressLine(prevValue)) {


### PR DESCRIPTION
## What?

Move onChange handler to actual input element.
Update input value when selecting suggestion.
Call either onNotFound OR onSelect.
Call reset function on clear.
Respond to empty input field in parent component.
Skip passing `itemToString` and `selectedItem` from `useCombobox` (not needed).

## Why?

There's a known issue in Downshift relating to this: https://github.com/downshift-js/downshift/issues/1108. It happens when you are using a controlled input field. The reason is that the value is set asynchronously which is too late for React to handle the cursor correctly.

The suggested solution is to update the input value using the native onChange handler directly on the input element. This also means we need to update the input value when selecting an option. However, that almost feels more natural rather then letting Downshift handle that for us.

https://user-images.githubusercontent.com/1220232/123746428-ee138600-d8b1-11eb-8816-2f585088e083.mov

