### PR TITLE
Integrate address autocomplete type in API

### DIFF
--- a/src/Components/API/addressAutocomplete.ts
+++ b/src/Components/API/addressAutocomplete.ts
@@ -17,3 +17,10 @@ export type CompleteAddress = AddressSuggestion & {
   postalCode: string
   city: string
 }
+
+export type AddressAutocompleteType = 'STREET' | 'BUILDING' | 'APARTMENT'
+
+export type AddressAutocompleteQuery = (
+  searchTerm: string,
+  options?: { type: AddressAutocompleteType },
+) => Promise<AddressSuggestion[]>

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -162,7 +162,10 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
       if (prevSuggestion && isSameAddress(prevSuggestion, newSuggestion))
         return newSuggestion
 
-      const results = await api.addressAutocompleteQuery(newSuggestion.address)
+      const results = await api.addressAutocompleteQuery(
+        newSuggestion.address,
+        { type: 'APARTMENT' },
+      )
       if (results.length === 1) return newSuggestion
 
       return null

--- a/src/Components/Actions/AddressAutocompleteAction/useAddressSearch.ts
+++ b/src/Components/Actions/AddressAutocompleteAction/useAddressSearch.ts
@@ -46,9 +46,9 @@ const useAddressSearch = (
   >(null)
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300)
-  const [apiQuery, suggestionType] = React.useMemo(
-    () => getApiQuery(debouncedSearchTerm, suggestion),
-    [debouncedSearchTerm, suggestion],
+  const [apiQuery, suggestionType] = getApiQuery(
+    debouncedSearchTerm,
+    suggestion,
   )
 
   // @ts-ignore: clean-up function only needed conditionally

--- a/src/Components/Actions/AddressAutocompleteAction/utils.ts
+++ b/src/Components/Actions/AddressAutocompleteAction/utils.ts
@@ -3,19 +3,19 @@ import {
   CompleteAddress,
 } from '../../API/addressAutocomplete'
 
-export const formatAddressLine = (address: AddressSuggestion): string => {
-  if (address.streetName && address.streetNumber) {
-    let displayAddress = `${address.streetName} ${address.streetNumber}`
-    if (address.floor) {
-      displayAddress += `, ${address.floor}.`
+export const formatAddressLine = (suggestion: AddressSuggestion): string => {
+  if (suggestion.streetName && suggestion.streetNumber) {
+    let displayAddress = `${suggestion.streetName} ${suggestion.streetNumber}`
+    if (suggestion.floor) {
+      displayAddress += `, ${suggestion.floor}.`
     }
-    if (address.apartment) {
-      displayAddress += ` ${address.apartment}`
+    if (suggestion.apartment) {
+      displayAddress += ` ${suggestion.apartment}`
     }
     return displayAddress
   }
 
-  return address.address
+  return suggestion.address
 }
 
 export const formatPostalLine = (
@@ -29,9 +29,9 @@ export const formatPostalLine = (
 }
 
 export const formatAddressLines = (
-  address: AddressSuggestion,
+  suggestion: AddressSuggestion,
 ): [string, string | undefined] => {
-  return [formatAddressLine(address), formatPostalLine(address)]
+  return [formatAddressLine(suggestion), formatPostalLine(suggestion)]
 }
 
 export const isMatchingStreetName = (

--- a/src/Components/Actions/AddressAutocompleteAction/utils.ts
+++ b/src/Components/Actions/AddressAutocompleteAction/utils.ts
@@ -3,26 +3,33 @@ import {
   CompleteAddress,
 } from '../../API/addressAutocomplete'
 
-export const formatAddressLine = (suggestion: AddressSuggestion): string => {
-  if (suggestion.streetName && suggestion.streetNumber) {
-    let displayAddress = `${suggestion.streetName} ${suggestion.streetNumber}`
-    if (suggestion.floor) {
-      displayAddress += `, ${suggestion.floor}.`
+export const formatAddressLine = ({
+  streetName,
+  streetNumber,
+  floor,
+  apartment,
+  address,
+}: AddressSuggestion): string => {
+  if (streetName && streetNumber) {
+    let displayAddress = `${streetName} ${streetNumber}`
+    if (floor) {
+      displayAddress += `, ${floor}.`
     }
-    if (suggestion.apartment) {
-      displayAddress += ` ${suggestion.apartment}`
+    if (apartment) {
+      displayAddress += ` ${apartment}`
     }
     return displayAddress
   }
 
-  return suggestion.address
+  return address
 }
 
-export const formatPostalLine = (
-  address: AddressSuggestion,
-): string | undefined => {
-  if (address.city && address.postalCode) {
-    return `${address.postalCode} ${address.city}`
+export const formatPostalLine = ({
+  city,
+  postalCode,
+}: AddressSuggestion): string | undefined => {
+  if (city && postalCode) {
+    return `${postalCode} ${city}`
   }
 
   return undefined

--- a/src/package.ts
+++ b/src/package.ts
@@ -26,4 +26,8 @@ export {
   Variables as CreateQuoteVariables,
 } from './Components/API/createQuote'
 
-export { AddressSuggestion } from './Components/API/addressAutocomplete'
+export {
+  AddressSuggestion,
+  AddressAutocompleteType,
+  AddressAutocompleteQuery,
+} from './Components/API/addressAutocomplete'


### PR DESCRIPTION
## What

Pass adress autocomplete type based on picked suggestion.
Skip passing trailing space after street name.
Tweak api query string when searching for apartments.
Rename variables: "address" to "suggestion".

## Why

Be more explicit about what type of suggestions we are searching for: streets, buildings, or apartments.

## Demo

https://user-images.githubusercontent.com/1220232/123770739-cd0b5f00-d8ca-11eb-906b-a3995f2f73a3.mov