### PR TITLE
Prevent input field from overflowing

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -36,6 +36,7 @@ const STORE_KEY = {
 }
 
 const Container = styled.div`
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -58,6 +59,11 @@ const FakeInput = styled(Input)`
   padding: 0 16px;
   line-height: 1;
   font-size: 48px;
+
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 
   @media (min-width: 600px) {
     margin-top: 20px;
@@ -273,6 +279,7 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
           opacity: isAutocompleteActive ? 0 : 1,
         }}
         transition={{ ease: 'easeOut', duration: 0.25 }}
+        style={{ maxWidth: '100%' }}
       >
         <Card
           isFocused={isHovered}

--- a/src/Components/Actions/Common.tsx
+++ b/src/Components/Actions/Common.tsx
@@ -10,6 +10,7 @@ interface Focusable {
 
 export const CardPrimitive = styled(motion.form)<Focusable>`
   position: relative;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -41,6 +42,7 @@ const LoadingContainer = styled(motion.div)`
 
 const FormContents = styled(motion.div)`
   text-align: center;
+  max-width: 100%;
 `
 
 export const Card: React.FC<CardProps> = ({ loading, children, ...rest }) => (
@@ -72,6 +74,7 @@ export const Card: React.FC<CardProps> = ({ loading, children, ...rest }) => (
         overflow: 'hidden',
       }}
       transition={{ delay: 0.25, type: 'spring', stiffness: 400, damping: 100 }}
+      style={{ maxWidth: '100%' }}
     >
       <FormContents
         animate={{


### PR DESCRIPTION
## What

Make sure the input field respects the max width and padding of it's containers.
Truncate text (ellipsis) for very long addresses.

## Why

This is what happens today:

![Screenshot 2021-06-29 at 11 18 09](https://user-images.githubusercontent.com/1220232/123773873-3e4c1180-d8cd-11eb-957a-e00420325483.png)

## Demo

Mobile

![Screenshot 2021-06-29 at 11 21 53](https://user-images.githubusercontent.com/1220232/123773953-4d32c400-d8cd-11eb-9434-60ed2fe28098.png)

Desktop + truncate text

![Screenshot 2021-06-29 at 11 25 49](https://user-images.githubusercontent.com/1220232/123774012-558aff00-d8cd-11eb-9734-00dca3310378.png)

☝️ This is the one I'm not 100% sure on. Perhaps it's okey though in this case since it's more of a preview of your address and you can click it to view the full string.