### PR TITLE
Fix autocomplete content shift iOS

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -61,14 +61,13 @@ const Button = styled.button`
   }
 `
 
-const FakeInput = styled.span<{ fakePlaceholder: boolean }>`
+const FakeInput = styled.span<{ isMuted: boolean }>`
   display: block;
   max-width: 100%;
   padding: 0 16px;
   font-size: 20px;
   line-height: 1.5;
-  color: ${(props) =>
-    props.fakePlaceholder ? colorsV3.gray500 : colorsV3.gray900};
+  color: ${(props) => (props.isMuted ? colorsV3.gray500 : colorsV3.gray900)};
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
@@ -316,7 +315,7 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
           {props.tooltip ? <Tooltip tooltip={props.tooltip} /> : null}
           <Button onClick={handleButtonClick}>
             <FakeInput
-              fakePlaceholder={confirmedAddressLine === '' || searchTerm === ''}
+              isMuted={confirmedAddressLine === undefined && searchTerm === ''}
             >
               {fakeInputText}
             </FakeInput>

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -59,20 +59,27 @@ const Button = styled.button`
   @media (min-width: 600px) {
     padding-bottom: 24px;
   }
+
+  & > input[disabled]::placeholder {
+    -webkit-text-fill-color: ${colorsV3.gray500};
+  }
 `
 
 const FakeInput = styled(Input)`
+  max-width: 100%;
   margin-left: 0;
   margin-right: 0;
   padding: 0 16px;
   line-height: 1;
   font-size: 48px;
   color: ${colorsV3.gray900};
-
-  max-width: 100%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  &:disabled {
+    -webkit-text-fill-color: ${colorsV3.gray900};
+    opacity: 1;
+  }
 
   @media (min-width: 600px) {
     margin-top: 20px;

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -74,10 +74,6 @@ const FakeInput = styled.span<{ fakePlaceholder: boolean }>`
   overflow: hidden;
   cursor: text;
 
-  ::placeholder {
-    -webkit-text-fill-color: ${colorsV3.gray500};
-  }
-
   @media (min-width: 600px) {
     padding: 0 32px;
     font-size: 48px;

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -55,13 +55,10 @@ const Button = styled.button`
   outline: none;
   background: none;
   appearance: none;
+  cursor: text;
 
   @media (min-width: 600px) {
     padding-bottom: 24px;
-  }
-
-  & > input[disabled]::placeholder {
-    -webkit-text-fill-color: ${colorsV3.gray500};
   }
 `
 
@@ -76,9 +73,15 @@ const FakeInput = styled(Input)`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  cursor: text;
+
   &:disabled {
     -webkit-text-fill-color: ${colorsV3.gray900};
     opacity: 1;
+
+    ::placeholder {
+      -webkit-text-fill-color: ${colorsV3.gray500};
+    }
   }
 
   @media (min-width: 600px) {

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -41,7 +41,6 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  width: 100%;
 `
 
 const Card = styled(BaseCard)`
@@ -50,7 +49,7 @@ const Card = styled(BaseCard)`
 
 const Button = styled.button`
   width: 100%;
-  padding: 0 0 16px 0;
+  padding: 16px 0;
   border: none;
   outline: none;
   background: none;
@@ -58,39 +57,35 @@ const Button = styled.button`
   cursor: text;
 
   @media (min-width: 600px) {
-    padding-bottom: 24px;
+    padding: 24px 0;
   }
 `
 
-const FakeInput = styled(Input)`
+const FakeInput = styled.span<{ fakePlaceholder: boolean }>`
   max-width: 100%;
-  margin-left: 0;
-  margin-right: 0;
   padding: 0 16px;
-  line-height: 1;
-  font-size: 48px;
-  color: ${colorsV3.gray900};
+  font-size: 20px;
+  line-height: 1.5;
+  color: ${(props) =>
+    props.fakePlaceholder ? colorsV3.gray500 : colorsV3.gray900};
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   cursor: text;
 
-  &:disabled {
-    -webkit-text-fill-color: ${colorsV3.gray900};
-    opacity: 1;
-
-    ::placeholder {
-      -webkit-text-fill-color: ${colorsV3.gray500};
-    }
+  ::placeholder {
+    -webkit-text-fill-color: ${colorsV3.gray500};
   }
 
   @media (min-width: 600px) {
-    margin-top: 20px;
     padding: 0 32px;
+    font-size: 48px;
+    line-height: 1.25;
   }
 `
 
-const PostalAddress = styled.p`
+const PostalAddress = styled.span`
+  display: block;
   font-family: ${fonts.FAVORIT}, sans-serif;
   font-size: 16px;
   text-align: center;
@@ -305,6 +300,7 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
     ? formatAddressLines(confirmedAddress)
     : []
 
+  const fakeInputText = confirmedAddressLine || searchTerm || props.placeholder
   return (
     <Container>
       <motion.div
@@ -323,13 +319,10 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
           {props.tooltip ? <Tooltip tooltip={props.tooltip} /> : null}
           <Button onClick={handleButtonClick}>
             <FakeInput
-              placeholder={props.placeholder}
-              value={confirmedAddressLine || searchTerm}
-              disabled={true}
-              size={
-                (confirmedAddressLine || searchTerm || props.placeholder).length
-              }
-            />
+              fakePlaceholder={confirmedAddressLine === '' || searchTerm === ''}
+            >
+              {fakeInputText}
+            </FakeInput>
             {confirmedPostalLine ? (
               <PostalAddress>{confirmedPostalLine}</PostalAddress>
             ) : null}

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -41,15 +41,23 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
+  width: 100%;
 `
 
 const Card = styled(BaseCard)`
   width: 100%;
+`
 
-  padding-bottom: 24px;
+const Button = styled.button`
+  width: 100%;
+  padding: 0 0 16px 0;
+  border: none;
+  outline: none;
+  background: none;
+  appearance: none;
 
-  @media (max-width: 600px) {
-    padding-bottom: 16px;
+  @media (min-width: 600px) {
+    padding-bottom: 24px;
   }
 `
 
@@ -59,6 +67,7 @@ const FakeInput = styled(Input)`
   padding: 0 16px;
   line-height: 1;
   font-size: 48px;
+  color: ${colorsV3.gray900};
 
   max-width: 100%;
   text-overflow: ellipsis;
@@ -214,6 +223,10 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
     [store],
   )
 
+  const handleButtonClick = () => {
+    setIsAutocompleteActive(true)
+  }
+
   const handleClearInput = React.useCallback(() => {
     setSearchTerm('')
     setPickedSuggestion(null)
@@ -298,19 +311,19 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
           onMouseLeave={() => setIsHovered(false)}
         >
           {props.tooltip ? <Tooltip tooltip={props.tooltip} /> : null}
-
-          <FakeInput
-            placeholder={props.placeholder}
-            value={confirmedAddressLine || searchTerm}
-            onClick={() => setIsAutocompleteActive(true)}
-            onFocus={() => setIsAutocompleteActive(true)}
-            size={
-              (confirmedAddressLine || searchTerm || props.placeholder).length
-            }
-          />
-          {confirmedPostalLine ? (
-            <PostalAddress>{confirmedPostalLine}</PostalAddress>
-          ) : null}
+          <Button onClick={handleButtonClick}>
+            <FakeInput
+              placeholder={props.placeholder}
+              value={confirmedAddressLine || searchTerm}
+              disabled={true}
+              size={
+                (confirmedAddressLine || searchTerm || props.placeholder).length
+              }
+            />
+            {confirmedPostalLine ? (
+              <PostalAddress>{confirmedPostalLine}</PostalAddress>
+            ) : null}
+          </Button>
         </Card>
       </motion.div>
 

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -62,6 +62,7 @@ const Button = styled.button`
 `
 
 const FakeInput = styled.span<{ fakePlaceholder: boolean }>`
+  display: block;
   max-width: 100%;
   padding: 0 16px;
   font-size: 20px;


### PR DESCRIPTION
## The issue
When clicking the `FakeInput` and triggering the `Modal`, the content shifts out of the viewport in iOS Safari.
This is due to the `FakeInput` getting focus when tapping it and the browser thinks the bottom of the page should be in view. We're unable to fool Safari by setting the focus manually to the input in the `Modal`.

https://user-images.githubusercontent.com/6661511/123826409-07dbba00-d900-11eb-8a5c-937a6298e59e.MP4


## Possible solution (Updated)
Make the `FakeInput` a regular span instead to remove all events attached to the input that causes iOS Safari to focus the viewport to the lower bottom of the screen. Wrap it in a button, because that's it kind of what it is anyway, a toggle for the Modal. The drawback is that it requires the user to tap the input in the `Modal`, but that's pretty much what Apple wants you to do 🙃


https://user-images.githubusercontent.com/6661511/124129562-2f589100-da7e-11eb-86c3-03bed5caf3d1.mov

