### PR TITLE
AddressAutocomplete cancel button cursor

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -43,11 +43,13 @@ const ModalHeaderLabel = styled.label`
 
 const ModalHeaderButton = styled.button`
   border: 0;
-  background: transparent;
+  background: ${colorsV3.gray300};
+  border-radius: 4px;
   appearance: none;
   outline: 0;
   position: relative;
   z-index: 2;
+  cursor: pointer;
 
   color: ${colorsV3.black};
   font-family: ${fonts.FAVORIT};
@@ -55,7 +57,7 @@ const ModalHeaderButton = styled.button`
 
   &:focus {
     border-radius: 4px;
-    box-shadow: 0 0 0 3px ${colorsV3.purple300};
+    box-shadow: 0 0 0 2px ${colorsV3.purple300};
   }
 `
 

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -41,7 +41,7 @@ const ModalHeaderLabel = styled.label`
   font-weight: bold;
 `
 
-const ModalHeaderButton = styled.button`
+const DismissButton = styled.button`
   border: 0;
   background: ${colorsV3.gray300};
   border-radius: 4px;
@@ -164,9 +164,9 @@ const AddressAutocomplete: React.FC<Props> = (props) => {
           <ModalHeaderLabel>
             {keywords.addressAutoCompleteModalTitle}
           </ModalHeaderLabel>
-          <ModalHeaderButton onClick={onDismiss}>
+          <DismissButton onClick={onDismiss}>
             {keywords.addressAutoCompleteModalDismiss}
-          </ModalHeaderButton>
+          </DismissButton>
         </ModalHeaderRow>
 
         <Combobox.Field {...getComboboxProps()}>

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -57,7 +57,6 @@ const DismissButton = styled.button`
   font-size: 16px;
 
   &:focus {
-    border-radius: 4px;
     box-shadow: 0 0 0 2px ${colorsV3.purple300};
   }
 `

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocomplete.tsx
@@ -43,7 +43,8 @@ const ModalHeaderLabel = styled.label`
 
 const DismissButton = styled.button`
   border: 0;
-  background: ${colorsV3.gray300};
+  background: transparent;
+  padding: 4px 2px;
   border-radius: 4px;
   appearance: none;
   outline: 0;

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.stories.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.stories.tsx
@@ -21,5 +21,5 @@ Autocomplete.args = {
   isTransitioning: false,
   passageName: 'autocomplete',
   storeKey: 'address',
-  placeholder: 'Teststreet 12',
+  placeholder: 'Enter your home address',
 }


### PR DESCRIPTION
### What?

Minor changes to the dismiss button in `AddressAutocomplete.tsx`:
- Name changed from `ModalHeaderButton` to `DismissButton` (since that's the only thing it's used for)
- 'pointer' cursor
- A slightly thinner outline when the button is focused, and some padding :)

**Focused cancel button:**
![image](https://user-images.githubusercontent.com/42962286/124141622-d989e600-da89-11eb-85bf-97258f4f9cd8.png)
