### PR TITLE
[GRW-367] Keep stored address line in input field

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -154,17 +154,20 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
   const { store, setValue, removeValues } = React.useContext(StoreContext)
 
   const [isAutocompleteActive, setIsAutocompleteActive] = React.useState(false)
-  const [searchTerm, setSearchTerm] = React.useState('')
-
-  const [
-    pickedSuggestion,
-    setPickedSuggestion,
-  ] = React.useState<AddressSuggestion | null>(() => getAddressFromStore(store))
 
   const [
     confirmedAddress,
     setConfirmedAddress,
   ] = React.useState<CompleteAddress | null>(() => getAddressFromStore(store))
+
+  const [
+    pickedSuggestion,
+    setPickedSuggestion,
+  ] = React.useState<AddressSuggestion | null>(() => confirmedAddress)
+
+  const [searchTerm, setSearchTerm] = React.useState(() =>
+    confirmedAddress ? formatAddressLine(confirmedAddress) : '',
+  )
 
   const confirmSuggestion = React.useCallback(
     async (


### PR DESCRIPTION
Derive stored address ONCE reuse initial value.
Use formatted address line from initial confirmed address.


https://user-images.githubusercontent.com/1220232/124474090-668db180-dda0-11eb-8e54-d3cfcbe21da4.mov

_Referenced ticket(s): [GRW-367]_

[GRW-367]: https://hedvig.atlassian.net/browse/GRW-367