### PR TITLE
Center align clear symbol in input field (iOS)

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/Combobox.tsx
@@ -20,12 +20,12 @@ const ComboboxField = styled.div`
 const ClearButton = styled.button`
   position: absolute;
   right: 16px;
-  top: calc(50% - 9px);
+  top: calc(50% - (20px / 2));
   cursor: pointer;
-  height: 18px;
-  width: 18px;
+  height: 20px;
+  width: 20px;
   border: 0;
-  border-radius: 9px;
+  border-radius: 50%;
   background-color: ${colorsV3.gray500};
   outline: 0;
   padding: 0;
@@ -41,8 +41,8 @@ const ClearButton = styled.button`
   svg {
     display: block;
     margin: auto;
-    width: 60%;
-    height: 60%;
+    width: 12px;
+    height: 12px;
   }
 `
 


### PR DESCRIPTION
Preview on iOS:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-05 at 16 15 08](https://user-images.githubusercontent.com/1220232/124485009-6a273580-ddac-11eb-834c-f1e6d275e153.png)
