### PR TITLE
Add inputMode based on mask type

### DIFF
--- a/src/Components/Actions/TextAction/TextAction.tsx
+++ b/src/Components/Actions/TextAction/TextAction.tsx
@@ -20,6 +20,23 @@ import { ApiComponent } from '../../API/apiComponent'
 import animateScrollTo from 'animated-scroll-to'
 import { useAutoFocus } from '../../../Utils/useAutoFocus'
 
+const convertMaskToInputMode = (
+  type: MaskType,
+): React.HTMLAttributes<HTMLInputElement>['inputMode'] => {
+  switch (type) {
+    case 'BirthDate':
+    case 'BirthDateReverse':
+    case 'NorwegianPostalCode':
+    case 'PersonalNumber':
+    case 'PostalCode':
+      return 'numeric'
+    case 'Email':
+      return 'email'
+    default:
+      return 'text'
+  }
+}
+
 const BottomSpacedInput = styled(Input)`
   margin-bottom: 24px;
 
@@ -104,6 +121,7 @@ export const TextAction: React.FunctionComponent<TextActionProps> = (props) => {
         <Masked
           inputRef={inputRef}
           mask={props.mask}
+          inputMode={props.mask ? convertMaskToInputMode(props.mask) : 'text'}
           type={props.mask === 'Email' ? 'email' : 'text'}
           size={Math.max(props.placeholder.length, textValue.length)}
           placeholder={props.placeholder}


### PR DESCRIPTION
Derive input mode from mask to select relevant keyboard for TextAction.

## Demo birth date input
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-09 at 10 53 22](https://user-images.githubusercontent.com/1220232/125053215-23378980-e0a5-11eb-8c93-3004d94592c7.png)

## Demo email input
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-09 at 10 53 51](https://user-images.githubusercontent.com/1220232/125053236-2a5e9780-e0a5-11eb-89e7-2c5705c211e9.png)
