### PR TITLE
Fix 'confirmSuggestion' function in AddressAutocompleteAction.tsx

### DIFF
--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -185,7 +185,10 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
         newSuggestion.address,
         { type: 'APARTMENT' },
       )
-      if (results.length === 1) return newSuggestion
+      if (results.length === 1 && isSameAddress(results[0], newSuggestion)) {
+        const apiSuggestion = results[0]
+        return isCompleteAddress(apiSuggestion) ? apiSuggestion : null
+      }
 
       return null
     },

--- a/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
+++ b/src/Components/Actions/AddressAutocompleteAction/AddressAutocompleteAction.tsx
@@ -186,6 +186,7 @@ export const AddressAutocompleteAction: React.FC<AddressAutocompleteActionProps>
         { type: 'APARTMENT' },
       )
       if (results.length === 1 && isSameAddress(results[0], newSuggestion)) {
+        // API response includes "property" bbrId since we asked for type = "APARTMENT"
         const apiSuggestion = results[0]
         return isCompleteAddress(apiSuggestion) ? apiSuggestion : null
       }

--- a/src/Components/Actions/MultiAction/InlineNumberAction.tsx
+++ b/src/Components/Actions/MultiAction/InlineNumberAction.tsx
@@ -11,30 +11,30 @@ const Container = styled.div`
 `
 
 const Input = styled.input`
-    margin-left: 16px;
-    margin-right: 16px;
-    font-size: 56px;
-    line-height: 1;
-    font-family: ${fonts.FAVORIT}
-    background: none;
-    border: none;
-    box-sizing: border-box;
-    text-align: center;
-    max-width: 100%;
-    margin-top: 16px;
-    color: ${colorsV3.gray900};
-    outline: 0;
-    ::placeholder {
-        color: ${colorsV3.gray500};
-    }
+  margin-left: 16px;
+  margin-right: 16px;
+  font-size: 56px;
+  line-height: 1;
+  font-family: ${fonts.FAVORIT};
+  background: none;
+  border: none;
+  box-sizing: border-box;
+  text-align: center;
+  max-width: 100%;
+  margin-top: 16px;
+  color: ${colorsV3.gray900};
+  outline: 0;
+  ::placeholder {
+    color: ${colorsV3.gray500};
+  }
 
-    ::-webkit-outer-spin-button,
-    ::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-    appearance: none;
-    -moz-appearance: textfield;
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  appearance: none;
+  -moz-appearance: textfield;
 `
 
 const Unit = styled.p`


### PR DESCRIPTION
Update function to confirm a selected address suggestion.
Make sure to always send the property ID instead of the access ID for houses.

...also adds a missing semicolon in emotion component.

## Why

The address for a house has two separate IDs - access and property. We always want to send the property ID to the API. There's no obvious way to tell them apart. Therefore we accidentally sent the access ID.

After this update: to verify a selected house address we:
1. make a second call to the API
2. compare that we only receive a single suggestion for that street address
3. assuming that this suggestion includes the property ID we assign that as the "confirmed address"
4. when user clicks "continue" we submit it to the store