### PR TITLE
Update to moving-flow-SE

### DIFF
--- a/angel-data/moving-flow-SE.json
+++ b/angel-data/moving-flow-SE.json
@@ -2,7 +2,7 @@
   "id": "0e9214ae-d578-43b1-8e67-cdbb5aeddfd3",
   "ifid": "29F1BC05-1702-4DA0-B866-9139E5B2C621",
   "keywords": {},
-  "lastUpdate": "2021-07-09T10:30:04.249Z",
+  "lastUpdate": "2021-07-14T13:38:02.932Z",
   "locales": [
     "en_SE"
   ],
@@ -397,7 +397,7 @@
       "selected": false,
       "story": "0e9214ae-d578-43b1-8e67-cdbb5aeddfd3",
       "tags": [],
-      "text": "<Message>\n  {EMBARK_MOVING_SE_OLD_HOME_INSURED_MESSAGE_1} DD-MM-YYYY\n</Message>\n\n<Message>\n  {EMBARK_MOVING_SE_OLD_HOME_INSURED_MESSAGE_2}\n</Message>\n\n<SelectAction>\n  <Option>\n    [[{EMBARK_MOVING_SE_CONTINUE_TO_OFFER_BUTTON}->Offer]]\n    <Tooltip>\n      <Title>\n        {EMBARK_MOVING_SE_OLD_HOME_INSURED_TITLE}\n      </Title>\n      <Description>\n        {EMBARK_MOVING_SE_OLD_HOME_INSURED_DESCRIPTION}\n      </Description>\n    </Tooltip>\n  </Option>\n</SelectAction>",
+      "text": "<Message>\n  {EMBARK_MOVING_SE_OLD_HOME_INSURED_MESSAGE_1}\n</Message>\n\n<Message>\n  {EMBARK_MOVING_SE_OLD_HOME_INSURED_MESSAGE_2}\n</Message>\n\n<SelectAction>\n  <Option>\n    [[{EMBARK_MOVING_SE_CONTINUE_TO_OFFER_BUTTON}->Offer]]\n    <Tooltip>\n      <Title>\n        {EMBARK_MOVING_SE_OLD_HOME_INSURED_TITLE}\n      </Title>\n      <Description>\n        {EMBARK_MOVING_SE_OLD_HOME_INSURED_DESCRIPTION}\n      </Description>\n    </Tooltip>\n  </Option>\n</SelectAction>",
       "top": 1300,
       "url": "/old_home_insured_until",
       "width": 100


### PR DESCRIPTION
We cant calculate dates in embark yet, so we need to remove the date from `EMBARK_MOVING_SE_OLD_HOME_INSURED_MESSAGE_1` and instead use the text "OK. Just so you know, we’ll also cover your old place 30 days after you moved.". 